### PR TITLE
課題33(pagination) に後方がはみ出る場合のテストケースを追加

### DIFF
--- a/problems/pagination/problem_ja.md
+++ b/problems/pagination/problem_ja.md
@@ -34,6 +34,7 @@ console.log(getPageNums(4, 6, 5));
 console.log(getPageNums(3, 8, 6));
 console.log(getPageNums(4, 8, 6));
 console.log(getPageNums(4, 8, 3));
+console.log(getPageNums(8, 8, 3));
 ```
 
 - `current = 1`, `total = 5`, `size = 5`
@@ -48,6 +49,8 @@ console.log(getPageNums(4, 8, 3));
 - return: `[2, 3, 4, 5, 6, 7]`
 - `current = 4`, `total = 8`, `size = 3`
 - return: `[3, 4, 5]`
+- `current = 8`, `total = 8`, `size = 3`
+- return: `[6, 7, 8]`
 
 次のコマンドを実行し、あなたのプログラムが正しく動くか確認しましょう。
 

--- a/solutions/pagination/index.js
+++ b/solutions/pagination/index.js
@@ -21,3 +21,4 @@ console.log(getPageNums(4, 6, 5));
 console.log(getPageNums(3, 8, 6));
 console.log(getPageNums(4, 8, 6));
 console.log(getPageNums(4, 8, 3));
+console.log(getPageNums(8, 8, 3));


### PR DESCRIPTION
## 背景
課題33の変更前のテストケースでは、後方がはみ出る場合のテストケースがなかったため、前方のはみ出しのみ対応したコードでもテストが通ってしまっていた。

## 変更内容
後方のはみ出しを確認するテストケースを追加した。

## 動作確認
rootにpagination.jsを追加し動かした。

### 成功する場合

https://github.com/recruit-tech/javascripting/assets/82492270/961c9afd-519b-44f9-89a3-abf5468881bd

### 失敗する場合

https://github.com/recruit-tech/javascripting/assets/82492270/5eee3e91-05da-467c-a7ee-316c331f54d9


